### PR TITLE
Fix: remove mastodon attribution to lockdown account

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -26,13 +26,6 @@ const config: Config = {
 
   headTags: [
     {
-      tagName: "meta",
-      attributes: {
-        name: "fediverse:creator",
-        content: "@lockdownsystems@infosec.exchange",
-      },
-    },
-    {
       tagName: "link",
       attributes: {
         href: "https://infosec.exchange/@lockdownsystems",


### PR DESCRIPTION
Removing attribution to the Mastodon Lockdown Systems account should re-install attribution to the Mastodon Cyd account.