### PR TITLE
Update download.tsx: fix linux URL

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -234,7 +234,7 @@ function getPlatforms(): Record<string, PlatformInfo> {
       downloads: [
         {
           label: "Linux Instructions",
-          url: "/docs/getting-started/download#cyd-for-linux",
+          url: "/docs/desktop/download#cyd-for-linux",
         },
       ],
     },


### PR DESCRIPTION
https://cyd.social/docs/getting-started/download#cyd-for-linux is 404

I believe it should be this: https://cyd.social/docs/desktop/download#cyd-for-linux