### PR TITLE
Fix(minor): fix linux download broken link

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -234,7 +234,7 @@ function getPlatforms(): Record<string, PlatformInfo> {
       downloads: [
         {
           label: "Linux Instructions",
-          url: "/docs/getting-started/download#cyd-for-linux",
+          url: "/docs/desktop/download/#cyd-for-linux",
         },
       ],
     },


### PR DESCRIPTION
This fixes the broken link for Linux's download instructions