### PR TITLE
Update pricing to include monthly

### DIFF
--- a/src/pages/pricing.module.css
+++ b/src/pages/pricing.module.css
@@ -72,21 +72,55 @@
   margin-bottom: 20px;
 }
 
-.price {
-  margin-bottom: 30px;
+.billingToggleBlock {
+  text-align: center;
+  margin: 24px 0 30px;
 }
 
-.price strong {
-  font-size: 1.75rem;
+.billingToggle {
+  display: inline-flex;
+  gap: 0;
+  border-radius: 999px;
+  padding: 3px;
+  background: #eef2f5;
+}
+
+.billingToggleActive,
+.billingToggleInactive {
+  border: 0;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.6rem 1rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.billingToggleActive {
+  background: #2e3440;
+  color: #ffffff;
+}
+
+.billingToggleInactive {
+  background: transparent;
+  color: #5e6b73;
+}
+
+.billingPrice {
+  margin-top: 16px;
+}
+
+.billingRate {
+  display: block;
+  font-size: 1.5rem;
   font-weight: 700;
   color: #2e3440;
 }
 
-.priceNote {
-  font-size: 0.875rem;
+.billingNote {
+  margin-top: 4px;
+  font-size: 0.95rem;
   color: #5e6b73;
-  display: inline;
-  margin-left: 5px;
 }
 
 .buttonContainer {
@@ -167,6 +201,16 @@
 @media (max-width: 480px) {
   .articleTitle {
     font-size: 1.75rem;
+  }
+
+  .billingToggle {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .billingToggleActive,
+  .billingToggleInactive {
+    flex: 1;
   }
 
   .pricingColumn {

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -11,11 +11,12 @@ interface FeatureItem {
 interface PricingPlan {
   name: string;
   description: string;
-  price?: string;
-  priceNote?: string;
   buttonText: string;
   buttonUrl: string;
   buttonStyle: "free" | "premium";
+  monthlyPriceCents?: number;
+  annualPriceCents?: number;
+  billingRateSuffix?: string;
   featuresHeader?: string;
   features?: FeatureItem[];
   xFeaturesHeader?: string;
@@ -23,6 +24,10 @@ interface PricingPlan {
   blueskyFeaturesHeader?: string;
   blueskyFeatures?: FeatureItem[];
 }
+
+type BillingPeriod = "monthly" | "annual";
+
+const formatDollars = (cents: number) => (cents / 100).toFixed(0);
 
 const pricingPlans: PricingPlan[] = [
   {
@@ -67,12 +72,13 @@ const pricingPlans: PricingPlan[] = [
   {
     name: "Premium",
     description:
-      "With a premium plan, you can selectively delete other data too.",
-    price: "$36 USD",
-    priceNote: "per year",
+      "With Premium, you can selectively delete other data too.",
     buttonText: "Get Premium",
     buttonUrl: "https://dash.cyd.social/#/dashboard/buy",
     buttonStyle: "premium",
+    monthlyPriceCents: 400,
+    annualPriceCents: 3600,
+    billingRateSuffix: " / month",
     blueskyFeaturesHeader: "Bluesky Features",
     blueskyFeatures: [
       { text: "Everything in the free plan", included: true },
@@ -104,11 +110,12 @@ const pricingPlans: PricingPlan[] = [
     name: "Cyd for Teams",
     description:
       "Give your employees privacy, peace of mind, and protection from doxing and harassment.",
-    price: "$36 USD",
-    priceNote: "/user/year (plus taxes)",
     buttonText: "Get Cyd for Teams",
     buttonUrl: "https://dash.cyd.social/#/teams/new",
     buttonStyle: "premium",
+    monthlyPriceCents: 400,
+    annualPriceCents: 3600,
+    billingRateSuffix: " / user / month",
     featuresHeader: "Features",
     features: [
       {
@@ -126,17 +133,59 @@ const pricingPlans: PricingPlan[] = [
   },
 ];
 
+function intervalLabel(billingPeriod: BillingPeriod): string {
+  return billingPeriod === "monthly" ? "1 Month" : "12 Months";
+}
+
+function intervalRateLabel(plan: PricingPlan, billingPeriod: BillingPeriod): string {
+  const monthlyEquivalentCents =
+    billingPeriod === "monthly"
+      ? plan.monthlyPriceCents || 0
+      : Math.round((plan.annualPriceCents || 0) / 12);
+
+  return `$${formatDollars(monthlyEquivalentCents)}${plan.billingRateSuffix || " / month"}`;
+}
+
 function PricingCard({ plan }: { plan: PricingPlan }) {
+  const [billingPeriod, setBillingPeriod] = React.useState<BillingPeriod>("annual");
+
   return (
     <div className={styles.pricingColumn}>
       <div className={styles.pricingHeader}>
         <h2>{plan.name}</h2>
         <p className={styles.description}>{plan.description}</p>
-        {plan.price && (
-          <p className={styles.price}>
-            <strong>{plan.price}</strong>
-            <span className={styles.priceNote}>{plan.priceNote}</span>
-          </p>
+        {plan.buttonStyle === "premium" && (
+          <div className={styles.billingToggleBlock}>
+            <div className={styles.billingToggle} role="group" aria-label={`${plan.name} billing period`}>
+              <button
+                type="button"
+                className={
+                  billingPeriod === "monthly"
+                    ? styles.billingToggleActive
+                    : styles.billingToggleInactive
+                }
+                onClick={() => setBillingPeriod("monthly")}
+              >
+                1 Month
+              </button>
+              <button
+                type="button"
+                className={
+                  billingPeriod === "annual"
+                    ? styles.billingToggleActive
+                    : styles.billingToggleInactive
+                }
+                onClick={() => setBillingPeriod("annual")}
+              >
+                12 Months
+              </button>
+            </div>
+            <div className={styles.billingPrice}>
+              <span className={styles.billingRate}>
+                {intervalRateLabel(plan, billingPeriod)}
+              </span>
+            </div>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
**Note: only merge this _after_ https://github.com/lockdown-systems/cyd-server/pull/191 has been merged and deployed to prod.**

This updates the pricing page so that now Premium and Cyd for Teams both have a "1 month"/"12 month" toggle, and so that it always displays the price by the month, never by the year. Psychology, amirite?

<img width="373" height="364" alt="Screenshot 2026-07-08 at 8 28 10 PM" src="https://github.com/user-attachments/assets/80e99e9b-94e1-4814-b3b1-86d023d392db" />

<img width="377" height="356" alt="Screenshot 2026-07-08 at 8 28 21 PM" src="https://github.com/user-attachments/assets/764e6cf7-6200-46ce-8533-151aae96b2d9" />

As much as Proton is sleezy as a company, I stole the idea from their upsell page:

<img width="1221" height="597" alt="Screenshot 2026-07-08 at 8 29 02 PM" src="https://github.com/user-attachments/assets/07f2e80c-1151-45cd-968b-7618af5e4df7" />
